### PR TITLE
[INJIMOB-2160] update library jar version to 0.6.0-SNAPSHOT

### DIFF
--- a/kotlin/PixelPass/publish-artifact.gradle
+++ b/kotlin/PixelPass/publish-artifact.gradle
@@ -104,7 +104,7 @@ publishing {
             artifact(tasks.named("jarRelease").get())
             groupId = "io.mosip"
             artifactId = "pixelpass-jar"
-            version = "0.5.0-SNAPSHOT"
+            version = "0.6.0-SNAPSHOT"
             artifact(tasks.named("javadocJar").get())
             artifact(tasks.named("sourcesJar").get())
             pom {


### PR DESCRIPTION
expose method for decoding base64 encoded CBOR data