### PR TITLE
[INJIWEB-1430]: New API to generate QR code with allowed size limit parameter

### DIFF
--- a/kotlin/PixelPass/src/commonMain/kotlin/io/mosip/pixelpass/PixelPass.kt
+++ b/kotlin/PixelPass/src/commonMain/kotlin/io/mosip/pixelpass/PixelPass.kt
@@ -14,6 +14,7 @@ import io.mosip.pixelpass.cose.CwtCryptoCtx
 import io.mosip.pixelpass.shared.DEFAULT_ZIP_FILE_NAME
 import io.mosip.pixelpass.cose.KeyUtil
 import io.mosip.pixelpass.cose.Util
+import io.mosip.pixelpass.exception.QrDataOverflowException
 import io.mosip.pixelpass.shared.ZIP_HEADER
 import io.mosip.pixelpass.shared.decodeHex
 import io.mosip.pixelpass.types.ECC
@@ -50,11 +51,10 @@ class PixelPass {
         header: String = ""
     ): String {
         val dataWithHeader = generateQRData(data, header)
-        return if (allowedQRDataSizeLimit > dataWithHeader.length) {
-            convertQrDataIntoBase64(dataWithHeader, ecc)
-        } else {
-            ""
+        if (dataWithHeader.length > allowedQRDataSizeLimit) {
+            throw QrDataOverflowException()
         }
+        return convertQrDataIntoBase64(dataWithHeader, ecc)
     }
 
     fun decode(data: String): String {

--- a/kotlin/PixelPass/src/commonMain/kotlin/io/mosip/pixelpass/PixelPass.kt
+++ b/kotlin/PixelPass/src/commonMain/kotlin/io/mosip/pixelpass/PixelPass.kt
@@ -43,6 +43,20 @@ class PixelPass {
         return qrcodeImage
     }
 
+    fun generateQRCodeWithinLimit(
+        allowedQRDataSizeLimit: Int,
+        data: String,
+        ecc: ECC = ECC.L,
+        header: String = ""
+    ): String {
+        val dataWithHeader = generateQRData(data, header)
+        return if (allowedQRDataSizeLimit > dataWithHeader.length) {
+            convertQrDataIntoBase64(dataWithHeader, ecc)
+        } else {
+            ""
+        }
+    }
+
     fun decode(data: String): String {
         val decodedBase45Data = Base45.getDecoder().decode(data)
         val decompressedData = ZLib().decode(decodedBase45Data)

--- a/kotlin/PixelPass/src/commonMain/kotlin/io/mosip/pixelpass/exception/QrDataOverflowException.kt
+++ b/kotlin/PixelPass/src/commonMain/kotlin/io/mosip/pixelpass/exception/QrDataOverflowException.kt
@@ -1,0 +1,5 @@
+package io.mosip.pixelpass.exception
+
+import io.mosip.pixelpass.shared.QrDataOverFlowExceptionMessage
+
+class QrDataOverflowException : RuntimeException(QrDataOverFlowExceptionMessage)

--- a/kotlin/PixelPass/src/commonMain/kotlin/io/mosip/pixelpass/shared/Constants.kt
+++ b/kotlin/PixelPass/src/commonMain/kotlin/io/mosip/pixelpass/shared/Constants.kt
@@ -7,3 +7,5 @@ const val QR_QUALITY = 100
 const val DEFAULT_ZLIB_COMPRESSION_LEVEL = 9
 const val ZIP_HEADER = "PK"
 const val DEFAULT_ZIP_FILE_NAME = "certificate.json"
+
+const val QrDataOverFlowExceptionMessage = "QR data size exceeds the allowed limit"

--- a/kotlin/Readme.md
+++ b/kotlin/Readme.md
@@ -38,6 +38,18 @@ Both Kotlin and Java packages are compiled from same Kotlin codebase. They are a
 
 returns a Bitmap image with header prepended if provided.
 
+`generateQRCodeWithinLimit(allowedQRDataSizeLimit, data, ecc, header )`
+
+`allowedQRDataSizeLimit` - Size Limit for Qr Data length. If it exceeds the limit, `QrDataOverflowException` will be thrown.
+
+`data` - Data needs to be compressed and encoded
+
+`ecc` - Error Correction Level for the QR generated. defaults to `"L"`
+
+`header` - Data header need to be prepend to identify the encoded data. defaults to `""`
+
+returns a Bitmap image with header prepended if provided.
+
 `generateQRData( data, header )`
 
 `data` - Data needs to be compressed and encoded


### PR DESCRIPTION
[INJIWEB-1430](https://mosip.atlassian.net/browse/INJIWEB-1430) - As part of adapting KMP pixelpass artifacts in mimoto.

[INJIWEB-1430]: https://mosip.atlassian.net/browse/INJIWEB-1430?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ