### PR TITLE
fix: maven publish workflow failure

### DIFF
--- a/kotlin/PixelPass/build.gradle.kts
+++ b/kotlin/PixelPass/build.gradle.kts
@@ -192,6 +192,22 @@ tasks.register("generatePom") {
     dependsOn("generatePomFileForAarPublication", "generatePomFileForJarReleasePublication")
 }
 
+afterEvaluate {
+    val signTasks = listOf("signJarReleasePublication", "signAarPublication")
+    val publishTasks = listOf(
+        "publishAarPublicationToLocalMavenWithChecksumsRepository",
+        "publishJarReleasePublicationToLocalMavenWithChecksumsRepository",
+        "publishAarPublicationToMavenLocal",
+        "publishJarReleasePublicationToMavenLocal",
+        "publishAarPublicationToPixelpassRepository",
+        "publishJarPublicationToPixelpassRepository",
+    )
+
+    publishTasks.forEach { publishName ->
+        tasks.findByName(publishName)?.dependsOn(signTasks[0], signTasks[1])
+    }
+}
+
 apply(from = "publish-artifact.gradle")
 
 var buildDir = project.layout.buildDirectory.get()


### PR DESCRIPTION
maven publish artifacts failing due to sign task dependency issue, so added signTasks  as dependent of publish tasks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced build process to enforce artifact signing before publishing to repositories. All artifacts are now required to be signed prior to distribution, ensuring secure and verified releases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->